### PR TITLE
Add MCP watchdog autostart service

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,13 @@ $exec = $server.OrchestrationEngine.CodeExecutionEngine.Execute('PowerShell', $c
 3. Initialize the tool registry with your organizational parameters
 4. Begin issuing natural language automation requests
 
+### Autostart Service
+Use `scripts/install-autostart.ps1` to register the watchdog service that keeps
+the MCP server running. The script detects Windows or Linux and installs either
+a Windows service or a systemd unit which launches `watchdog.ps1`. Run the
+script with administrative privileges so the server starts automatically and
+recovers from failures.
+
 ### Enterprise Deployment
 For production environments, refer to the deployment guide in `/docs/deployment/` for:
 - Service account configuration

--- a/scripts/install-autostart.ps1
+++ b/scripts/install-autostart.ps1
@@ -1,0 +1,61 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    Installs or updates the MCP Server watchdog service for automatic start.
+.DESCRIPTION
+    Creates a platform-appropriate service entry that launches the watchdog
+    script which ensures the MCP server stays running. Supports Windows
+    (New-Service) and Linux (systemd). Requires administrator or root rights.
+#>
+
+param(
+    [string]$ServiceName = "PierceMCP",
+    [string]$ServerScript = (Join-Path $PSScriptRoot '..\src\MCPServer.ps1'),
+    [string]$WatchdogScript = (Join-Path $PSScriptRoot 'watchdog.ps1')
+)
+
+function Install-WindowsService {
+    param([string]$name, [string]$binaryPath)
+
+    $svc = Get-Service -Name $name -ErrorAction SilentlyContinue
+    if (-not $svc) {
+        New-Service -Name $name -BinaryPathName $binaryPath -Description 'Pierce County MCP Server Watchdog' -StartupType Automatic
+    } else {
+        Set-Service -Name $name -StartupType Automatic
+        $wmi = Get-WmiObject -Class Win32_Service -Filter "Name='$name'"
+        $null = $wmi.Change($null,$null,$null,$null,$null,$null,$binaryPath,$null,$null,$null)
+    }
+    Start-Service -Name $name
+}
+
+function Install-SystemdService {
+    param([string]$name, [string]$binaryPath)
+
+    $servicePath = "/etc/systemd/system/$name.service"
+    $content = @"
+[Unit]
+Description=Pierce County MCP Server Watchdog
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=$binaryPath
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+"@
+    Set-Content -Path $servicePath -Value $content -Force
+    systemctl daemon-reload
+    systemctl enable $name
+    systemctl restart $name
+}
+
+$binary = "pwsh -NoProfile -ExecutionPolicy Bypass -File `"$WatchdogScript`" -ServerScript `"$ServerScript`""
+
+if ($IsWindows) {
+    Install-WindowsService -name $ServiceName -binaryPath $binary
+} else {
+    Install-SystemdService -name $ServiceName -binaryPath $binary
+}

--- a/src/Core/HealthMonitor.ps1
+++ b/src/Core/HealthMonitor.ps1
@@ -1,5 +1,3 @@
-cat <<'EOF' > src/Core/HealthMonitor.ps1
-cat > src/Core/HealthMonitor.ps1 <<'EOF'
 #Requires -Version 7.0
 <#
 .SYNOPSIS


### PR DESCRIPTION
## Summary
- fix stray lines in `HealthMonitor.ps1`
- add cross-platform script `install-autostart.ps1`
- document service setup in README

## Testing
- `pwsh -NoLogo -File scripts/test-syntax.ps1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e99f39960832d8f41139f2a580beb