### PR TITLE
Add PR suggestion engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ For production environments, refer to the deployment guide in `/docs/deployment/
 - `get_ad_object_attributes`: Active Directory queries
 - `get_entra_object_attributes`: Azure AD object inspection
 - `code_execution`: Secure sandboxed script execution and validation
+- `pr_suggestion`: Automatic draft and submission of pull requests with full test logs
 
 ## MONITORING & TELEMETRY
 
@@ -256,12 +257,27 @@ For production environments, refer to the deployment guide in `/docs/deployment/
 - Automated testing and validation pipelines
 - Change approval workflows through ServiceNow
 - Documentation synchronization with code changes
+- **Internal PR Suggestion Tool**: Automatically drafts and submits pull requests for
+  all code changes, attaches test logs, and notifies maintainers. No change is merged
+  without human review and approval.
 
 ### Continuous Improvement
 - Monthly performance reviews and optimization
 - Quarterly security assessments and updates
 - Annual compliance audits and certifications
 - User feedback integration and feature development
+
+### Using the PR Suggestion Tool
+The `PRSuggestionEngine` module automates code change packaging into pull requests. Example:
+
+```powershell
+$engine = [PRSuggestionEngine]::new('C:\Repo')
+$tests = @('.\scripts\test-core-modules.ps1', '.\scripts\test-syntax.ps1')
+$engine.SuggestPullRequest('Update validation logic', $tests)
+```
+
+The engine commits local changes to a dedicated branch, runs the provided tests, creates
+a pull request via `gh`, logs the activity, and sends a Teams notification.
 
 ## TECHNICAL SPECIFICATIONS
 

--- a/scripts/suggest-pr.ps1
+++ b/scripts/suggest-pr.ps1
@@ -1,0 +1,12 @@
+#Requires -Version 7.0
+
+param(
+    [string]$Description,
+    [string[]]$Tests = @("$PSScriptRoot/test-core-modules.ps1", "$PSScriptRoot/test-syntax.ps1"),
+    [string]$RepoRoot = (Resolve-Path "$PSScriptRoot/.."),
+    [string]$NotifyEndpoint = ''
+)
+
+Import-Module "$PSScriptRoot/../src/Core/PRSuggestionEngine.ps1"
+$engine = [PRSuggestionEngine]::new($RepoRoot, 'main', $NotifyEndpoint)
+$engine.SuggestPullRequest($Description, $Tests)

--- a/src/Core/PRSuggestionEngine.ps1
+++ b/src/Core/PRSuggestionEngine.ps1
@@ -1,0 +1,68 @@
+#Requires -Version 7.0
+<%
+.SYNOPSIS
+    Pull Request Suggestion Engine for MCP Server
+.DESCRIPTION
+    Automatically packages code changes into a feature branch, runs tests and linting,
+    and opens a pull request with detailed logs. Supports audit logging and
+    notification to maintainers.
+.NOTES
+    Author: Pierce County IT Solutions Architecture
+    Compliance: GCC, SOC2, NIST
+%>
+
+using namespace System.IO
+
+class PRSuggestionEngine {
+    [string]$Repository
+    [string]$BaseBranch
+    [string]$NotificationEndpoint
+    [string]$LogPath
+
+    PRSuggestionEngine([string]$repository, [string]$baseBranch = 'main', [string]$notificationEndpoint = '', [string]$logPath = 'logs/pr-suggestions.log') {
+        $this.Repository = $repository
+        $this.BaseBranch = $baseBranch
+        $this.NotificationEndpoint = $notificationEndpoint
+        $this.LogPath = $logPath
+    }
+
+    [void]SuggestPullRequest([string]$changeDescription, [string[]]$testScripts) {
+        $timestamp = Get-Date -Format 'yyyyMMddHHmmss'
+        $branch = "pr-suggestion/$timestamp"
+
+        Push-Location $this.Repository
+        git checkout $this.BaseBranch | Out-Null
+        git checkout -b $branch | Out-Null
+        git add -A
+        $files = git status --short
+        $commitMsg = "feat: automated suggestion - $changeDescription"
+        git commit -m $commitMsg | Out-Null
+
+        $testLog = @()
+        foreach ($script in $testScripts) {
+            try {
+                $output = & $script 2>&1
+                $testLog += $output
+            } catch {
+                $testLog += $_.Exception.Message
+            }
+        }
+
+        $logBody = $testLog -join "`n"
+        $prBody = "### Change Description`n$changeDescription`n`n### Affected Files`n$files`n`n### Test Logs`n```
+$logBody
+```"
+
+        gh pr create --base $this.BaseBranch --head $branch --title $changeDescription --body $prBody | Out-Null
+        $prUrl = gh pr view --json url -q '.url'
+
+        $logEntry = "[$(Get-Date -Format o)] Created PR $prUrl for branch $branch"
+        $logEntry | Out-File -FilePath $this.LogPath -Append
+
+        if ($this.NotificationEndpoint) {
+            $payload = @{ text = "New PR Suggested: $prUrl - $changeDescription" } | ConvertTo-Json
+            Invoke-RestMethod -Uri $this.NotificationEndpoint -Method Post -Body $payload -ContentType 'application/json'
+        }
+        Pop-Location
+    }
+}


### PR DESCRIPTION
## Summary
- implement PRSuggestionEngine to automatically create draft pull requests
- provide `suggest-pr.ps1` helper script
- document the new tool in the README

## Testing
- `pwsh -NoLogo -Command ./scripts/test-syntax.ps1` *(fails: `pwsh: command not found`)*
- `pwsh -NoLogo -Command ./scripts/test-core-modules.ps1` *(fails: `pwsh: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685ea2e46398832d8816dd4196af5d42