### PR TITLE
Add simple usage guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ $search = $server.OrchestrationEngine.WebSearchEngine.Search('m365 mailbox deleg
 3. Initialize the tool registry with your organizational parameters
 4. Install Python dependencies with `pip install -r requirements.txt`
 5. Begin issuing natural language automation requests
+6. For a very simple overview, read `docs/HOW-TO-USE.md`
 
 ### Autostart Service
 Use `scripts/install-autostart.ps1` to register the watchdog service that keeps

--- a/docs/HOW-TO-USE.md
+++ b/docs/HOW-TO-USE.md
@@ -1,0 +1,14 @@
+# How To Use The Pierce County MCP Server
+
+This guide is written for very young users. It's super simple!
+
+1. **Ask the server.**
+   - Type a request like "Please make a new mailbox for toys" or "Give mom access to the family calendar." The MCP server understands regular sentences.
+2. **Wait a moment.**
+   - The server thinks about your request and does all the hard work by itself.
+3. **See the result.**
+   - The server writes down everything it did in the log file and tells you if it worked.
+4. **All done!**
+   - If something goes wrong, the server fixes it automatically or lets an adult know.
+
+That's it! The MCP server handles everything for you.


### PR DESCRIPTION
## Summary
- document quick "How To Use" instructions for young readers
- reference the new doc from README

## Testing
- `python3 -m py_compile src/python/internal_reasoning_engine.py`
- `pwsh ./scripts/test-syntax.ps1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eaef09b08832d9ad006d6e7d9adee