### PR TITLE
Fix metrics section in ToolRegistry

### DIFF
--- a/src/Core/ToolRegistry.ps1
+++ b/src/Core/ToolRegistry.ps1
@@ -507,11 +507,20 @@ class ToolRegistry {
         }
         
         # Add metrics section
+        # Metrics section is appended separately to avoid any parsing issues on
+        # older PowerShell versions. Build the strings first, then append.
         $null = $sb.AppendLine('# Tool Metrics')
+
         $sb.AppendLine("") | Out-Null
-        $sb.AppendLine("Last updated: $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')") | Out-Null
+
+        $timestamp = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+        $sb.AppendLine("Last updated: $timestamp") | Out-Null
+
         $sb.AppendLine("") | Out-Null
-        $sb.AppendLine("Total tools: $($this.Tools.Count)") | Out-Null
+
+        $toolCountLine = "Total tools: {0}" -f $this.Tools.Count
+        $sb.AppendLine($toolCountLine) | Out-Null
+
         $sb.AppendLine("") | Out-Null
         
         return $sb.ToString()


### PR DESCRIPTION
## Summary
- rework metrics string building in `ToolRegistry.ps1` to avoid parsing issues

## Testing
- `./scripts/test-syntax.ps1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eb9a71ab4832db805c63d4e727e01