### PR TITLE
Enable configurable AI providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,26 @@ $search = $server.OrchestrationEngine.WebSearchEngine.Search('m365 mailbox deleg
 6. For a very simple overview, read `docs/HOW-TO-USE.md`
 7. Validate the installation by running `./scripts/test-core-modules.ps1`
 
+### Configurable AI Model Providers
+AI providers are defined in `mcp.config.json`. Each provider entry includes an endpoint, model name, authentication, and timeout. Example:
+
+```json
+{
+  "DefaultAIProvider": "OllamaLocal",
+  "AIProviders": [
+    {
+      "Name": "OllamaLocal",
+      "Type": "REST",
+      "Endpoint": "http://localhost:11434/api/generate",
+      "Model": "llama2",
+      "TimeoutSec": 30
+    }
+  ]
+}
+```
+
+Swap providers or add new ones by editing this file and restarting the server. No code changes are required.
+
 ### Autostart Service
 Use `scripts/install-autostart.ps1` to register the watchdog service that keeps
 the MCP server running. The script detects Windows or Linux and installs either

--- a/mcp.config.json
+++ b/mcp.config.json
@@ -1,0 +1,12 @@
+{
+  "DefaultAIProvider": "OllamaLocal",
+  "AIProviders": [
+    {
+      "Name": "OllamaLocal",
+      "Type": "REST",
+      "Endpoint": "http://localhost:11434/api/generate",
+      "Model": "llama2",
+      "TimeoutSec": 30
+    }
+  ]
+}

--- a/scripts/test-core-modules.ps1
+++ b/scripts/test-core-modules.ps1
@@ -8,10 +8,11 @@ $repoRoot   = Split-Path -Parent $PSCommandPath | Split-Path -Parent
 $sourceRoot = Join-Path $repoRoot 'src'
 $coreModules = @(
     'Logger.ps1',
-    'VectorMemoryBank.ps1',
     'SemanticIndex.ps1',
-    'ContextManager.ps1',
+    'VectorMemoryBank.ps1',
     'EntityExtractor.ps1',
+    'ContextManager.ps1',
+    'AIManager.ps1',
     'ValidationEngine.ps1',
     'ToolRegistry.ps1',
     'SecurityManager.ps1',

--- a/scripts/test-mcp-modules.ps1
+++ b/scripts/test-mcp-modules.ps1
@@ -24,16 +24,17 @@ try {
     # Test each core module individually
     $coreModules = @(
         'Logger.ps1',
-        'VectorMemoryBank.ps1',
         'SemanticIndex.ps1',
-        'OrchestrationEngine.ps1',
+        'VectorMemoryBank.ps1',
         'EntityExtractor.ps1',
+        'ContextManager.ps1',
+        'AIManager.ps1',
+        'OrchestrationEngine.ps1',
         'ValidationEngine.ps1',
         'ToolRegistry.ps1',
         'SecurityManager.ps1',
         'ConfidenceEngine.ps1',
-        'InternalReasoningEngine.ps1',
-        'ContextManager.ps1'
+        'InternalReasoningEngine.ps1'
     )
     
     foreach ($module in $coreModules) {

--- a/src/Core/AIManager.ps1
+++ b/src/Core/AIManager.ps1
@@ -1,0 +1,109 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    Pluggable AI Provider Manager for MCP Server
+.DESCRIPTION
+    Provides dynamic configuration and invocation of external or local LLM endpoints.
+    Supports multiple providers and secure invocation with audit logging.
+#>
+
+using namespace System.Collections.Generic
+
+class AIProviderConfig {
+    [string]$Name
+    [string]$Type
+    [string]$Endpoint
+    [string]$Model
+    [hashtable]$Headers
+    [string]$AuthToken
+    [int]$TimeoutSec
+
+    AIProviderConfig() {
+        $this.Headers = @{}
+        $this.TimeoutSec = 30
+    }
+}
+
+class AIProvider {
+    [AIProviderConfig]$Config
+    [Logger]$Logger
+
+    AIProvider([AIProviderConfig]$cfg,[Logger]$logger) {
+        $this.Config = $cfg
+        $this.Logger = $logger
+    }
+
+    [hashtable] Invoke([hashtable]$payload) {
+        $headers = @{}
+        if ($this.Config.AuthToken) { $headers['Authorization'] = "Bearer $($this.Config.AuthToken)" }
+        foreach ($k in $this.Config.Headers.Keys) { $headers[$k] = $this.Config.Headers[$k] }
+        $payload.model = $this.Config.Model
+        $this.Logger.Debug('Invoking AI provider', @{Provider=$this.Config.Name; Endpoint=$this.Config.Endpoint})
+        try {
+            $resp = Invoke-RestMethod -Uri $this.Config.Endpoint -Method Post -Headers $headers -Body ($payload | ConvertTo-Json -Depth 5) -TimeoutSec $this.Config.TimeoutSec
+            $this.Logger.Info('AI provider response', @{Provider=$this.Config.Name; Length=($resp | Out-String).Length})
+            return $resp
+        } catch {
+            $this.Logger.Error('AI provider invocation failed', @{Provider=$this.Config.Name; Error=$_.Exception.Message})
+            throw
+        }
+    }
+}
+
+class AIManager {
+    [Dictionary[string,AIProvider]]$Providers
+    [string]$DefaultProvider
+    [Logger]$Logger
+
+    AIManager([Logger]$logger,[hashtable]$config) {
+        $this.Logger = $logger
+        $this.Providers = [Dictionary[string,AIProvider]]::new()
+        if($config -and $config.AIProviders){ $this.LoadProviders($config.AIProviders) }
+        if($config){ $this.DefaultProvider = $config.DefaultAIProvider }
+    }
+
+    [void] LoadProviders([object[]]$providerConfigs) {
+        foreach($p in $providerConfigs){
+            $cfg = [AIProviderConfig]::new()
+            $cfg.Name = $p.Name
+            $cfg.Type = $p.Type
+            $cfg.Endpoint = $p.Endpoint
+            $cfg.Model = $p.Model
+            $cfg.Headers = $p.Headers
+            $cfg.AuthToken = $p.AuthToken
+            if($p.TimeoutSec){ $cfg.TimeoutSec = [int]$p.TimeoutSec }
+            $prov = [AIProvider]::new($cfg,$this.Logger)
+            $this.Providers[$cfg.Name] = $prov
+        }
+    }
+
+    [AIProvider] GetProvider([string]$name) {
+        if(-not $name){ $name = $this.DefaultProvider }
+        $prov = $null
+        if($this.Providers.TryGetValue($name,[ref]$prov)){ return $prov }
+        throw "AI provider '$name' not found"
+    }
+
+    [string] InvokeCompletion([string]$prompt,[string]$providerName) {
+        $prov = $this.GetProvider($providerName)
+        $payload = @{ prompt = $prompt }
+        $res = $prov.Invoke($payload)
+        if($res.choices){ return $res.choices[0].text }
+        elseif($res.content){ return $res.content }
+        return $res | ConvertTo-Json -Depth 5
+    }
+
+    [EntityCollection] ParseEntities([string]$text,[string]$providerName) {
+        $prov = $this.GetProvider($providerName)
+        $payload = @{ input = $text; operation = 'parse_entities' }
+        $res = $prov.Invoke($payload)
+        $entities = [EntityCollection]::new()
+        foreach($u in $res.users){ $entities.AddUsers([UserEntity]::new($u)) }
+        foreach($m in $res.mailboxes){ $entities.AddMailboxes([MailboxEntity]::new($m,[MailboxType]::Shared)) }
+        foreach($g in $res.groups){ $entities.AddGroups([GroupEntity]::new($g)) }
+        foreach($a in $res.actions){ $act = [ActionEntity]::new([ActionType]::$('Generic')); $act.OriginalText = $a; $entities.AddActions($act) }
+        return $entities
+    }
+}
+
+Export-ModuleMember -Class AIManager, AIProvider, AIProviderConfig

--- a/src/Core/ContextManager.ps1
+++ b/src/Core/ContextManager.ps1
@@ -356,7 +356,7 @@ class ContextManager {
             })
         }
         catch {
-            $this.Logger.Warning("Failed to load persisted context", @{
+            $this.Logger.Warning("Failed to load persisted context", @{ Error = $_.Exception.Message })
         }
     }
     

--- a/src/Core/MCPServerClass.ps1
+++ b/src/Core/MCPServerClass.ps1
@@ -13,6 +13,7 @@ class MCPServer {
     hidden [OrchestrationEngine] $OrchestrationEngine
     hidden [PerformanceMonitor] $PerformanceMonitor
     hidden [AsyncRequestProcessor] $AsyncProcessor
+    hidden [AIManager] $AIManager
     hidden [hashtable] $Configuration
     hidden [string] $ServerVersion
     hidden [DateTime] $StartTime
@@ -42,8 +43,9 @@ class MCPServer {
             $this.PerformanceMonitor = [PerformanceMonitor]::new($this.Logger)
             $this.HealthMonitor = [HealthMonitor]::new($this.Logger)
             
-            # Initialize orchestration engine
-            $this.OrchestrationEngine = [OrchestrationEngine]::new($this.Logger)
+            # Initialize AI manager and orchestration engine
+            $this.AIManager = [AIManager]::new($this.Logger, $this.Configuration)
+            $this.OrchestrationEngine = [OrchestrationEngine]::new($this.Logger, $this.AIManager)
             $this.AsyncProcessor = [AsyncRequestProcessor]::new($this.OrchestrationEngine, $this.Logger, 4)
             
             # Register enterprise tools

--- a/src/MCPServer.ps1
+++ b/src/MCPServer.ps1
@@ -42,6 +42,7 @@ $coreModules = @(
     'InternalReasoningEngine.ps1', # Automated reasoning and correction
     'RuleBasedParser.ps1',     # Fallback regex/dictionary parser
     'EntityExtractor.ps1',      # Entity extraction
+    'AIManager.ps1',            # Configurable AI provider management
     'WebSearchEngine.ps1',     # Contextual web search
     'OrchestrationEngine.ps1',  # Main orchestration engine
     'AsyncRequestProcessor.ps1' # Parallel request processing
@@ -111,7 +112,11 @@ function Initialize-Configuration {
         ServerVersion = "2.1.0-rc"
     }
     
-    # Load configuration file if specified
+    # Load configuration file if specified, otherwise try repo config
+    if (-not $ConfigPath) {
+        $repoConfig = Join-Path $moduleRoot '..' 'mcp.config.json'
+        if (Test-Path $repoConfig) { $ConfigPath = $repoConfig }
+    }
     if ($ConfigPath -and (Test-Path $ConfigPath)) {
         try {
             $fileConfig = Get-Content $ConfigPath | ConvertFrom-Json -AsHashtable


### PR DESCRIPTION
## Summary
- add AIManager module to enable pluggable external LLMs
- allow configuring providers via new `mcp.config.json`
- wire AIManager into MCPServerClass and OrchestrationEngine
- document how to configure providers in README
- update tests to include new module

## Testing
- `pwsh ./scripts/test-core-modules.ps1` *(fails: Unable to find type [OrchestrationSession])* 
- `pwsh ./scripts/test-syntax.ps1`


------
https://chatgpt.com/codex/tasks/task_e_685ec0276138832dbba68e60b28e108a