### PR TITLE
Add Docker-based REST API gateway

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+__pycache__
+.memory-bank

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM mcr.microsoft.com/powershell:7.4-ubuntu-22.04
+
+WORKDIR /opt/mcp
+
+# Install Python and dependencies
+RUN apt-get update && \
+    apt-get install -y python3 python3-pip && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt requirements.txt
+RUN pip3 install --no-cache-dir -r requirements.txt
+
+COPY . /opt/mcp
+
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV MCP_SCRIPT=/opt/mcp/src/MCPServer.ps1
+
+EXPOSE 8080
+
+CMD ["uvicorn", "src.python.mcp_http_api:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/README.md
+++ b/README.md
@@ -217,6 +217,18 @@ a Windows service or a systemd unit which launches `watchdog.ps1`. Run the
 script with administrative privileges so the server starts automatically and
 recovers from failures.
 
+### Container Deployment
+Build the included Docker image to run the server behind a lightweight REST API:
+
+```bash
+docker build -t pierce-mcp .
+docker run -p 8080:8080 pierce-mcp
+```
+
+The container launches a FastAPI gateway that relays requests to the PowerShell
+orchestration engine. Specify an alternate script path with the `MCP_SCRIPT`
+environment variable if required.
+
 ### Enterprise Deployment
 For production environments, refer to the deployment guide in `/docs/deployment/` for:
 - Service account configuration
@@ -252,6 +264,10 @@ For production environments, refer to the deployment guide in `/docs/deployment/
 ```
 
 ## API REFERENCE
+
+When running in the Docker container, the server exposes these tools via a
+simple REST interface on port `8080`. Issue a `POST` to `/tools/call` with the
+tool name and parameters to execute a workflow.
 
 ### Core Tools
 - `deprovision_account`: Complete account deprovisioning workflow

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 requests>=2.31.0
+fastapi>=0.111.0
+uvicorn>=0.29.0

--- a/src/python/mcp_http_api.py
+++ b/src/python/mcp_http_api.py
@@ -1,0 +1,55 @@
+import asyncio
+import json
+import os
+import uuid
+import subprocess
+from typing import Any, Dict
+
+from fastapi import FastAPI, HTTPException
+
+SCRIPT_PATH = os.environ.get("MCP_SCRIPT", "/opt/mcp/src/MCPServer.ps1")
+
+class MCPBridge:
+    def __init__(self, script: str) -> None:
+        self.proc = subprocess.Popen([
+            "pwsh", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", script
+        ], stdin=subprocess.PIPE, stdout=subprocess.PIPE, text=True, bufsize=1)
+
+    async def send(self, method: str, params: Dict[str, Any] | None = None) -> Any:
+        request_id = str(uuid.uuid4())
+        request = {"jsonrpc": "2.0", "id": request_id, "method": method, "params": params or {}}
+        assert self.proc.stdin
+        self.proc.stdin.write(json.dumps(request) + "\n")
+        self.proc.stdin.flush()
+        while True:
+            line = await asyncio.get_event_loop().run_in_executor(None, self.proc.stdout.readline)
+            if not line:
+                raise HTTPException(status_code=500, detail="MCP server terminated")
+            try:
+                resp = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if resp.get("id") == request_id:
+                if "error" in resp:
+                    raise HTTPException(status_code=500, detail=resp["error"].get("message"))
+                return resp.get("result")
+
+    def stop(self) -> None:
+        if self.proc and self.proc.poll() is None:
+            self.proc.terminate()
+
+bridge = MCPBridge(SCRIPT_PATH)
+app = FastAPI()
+
+@app.on_event("shutdown")
+def shutdown_event() -> None:
+    bridge.stop()
+
+@app.post("/tools/call")
+async def call_tool(payload: Dict[str, Any]):
+    return await bridge.send("tools/call", payload)
+
+@app.get("/health")
+async def health() -> Dict[str, str]:
+    return {"status": "ok"}
+


### PR DESCRIPTION
## Summary
- provide Dockerfile and `.dockerignore`
- expose minimal FastAPI gateway `mcp_http_api.py`
- document container usage in README
- update Python requirements

## Testing
- `pwsh -NoProfile -ExecutionPolicy Bypass -File ./scripts/test-syntax.ps1`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File ./scripts/test-core-modules.ps1`


------
https://chatgpt.com/codex/tasks/task_e_685ee6c4d51c832dbf384c81fda534c8