### PR TITLE
Fix stray equals in MCPServerClass

### DIFF
--- a/src/Core/MCPServerClass.ps1
+++ b/src/Core/MCPServerClass.ps1
@@ -153,7 +153,6 @@ class MCPServer {
     
     hidden [hashtable] HandleRequest([hashtable]$request) {
         $this.PerformanceMonitor.StartOperation("MessageProcessing")
-         = 
         
         try {
             # Log incoming request (sanitized)


### PR DESCRIPTION
## Summary
- remove stray `=` that caused syntax parsing issues in `MCPServerClass.ps1`

## Testing
- `pwsh -NoProfile -File scripts/test-syntax.ps1`
- `pwsh -NoProfile -File scripts/test-core-modules.ps1`
- `pwsh -NoProfile -File scripts/test-mcp-modules.ps1` *(fails: Cannot bind argument to parameter 'Path' because it is null)*


------
https://chatgpt.com/codex/tasks/task_e_685ee9aad424832dbd0ce6edc650ae35