### PR TITLE
Add core module package and reasoning improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,11 @@ The engine now performs fuzzy matching against organizational directories when v
 
 **Python Implementation**
 
-To support advanced reasoning and easier integration with AI libraries, the reasoning component has been refactored into a standalone Python module located in `src/python/internal_reasoning_engine.py`. The PowerShell orchestration engine invokes this module for complex analysis, ensuring language-agnostic operation and modern extensibility.
+To support advanced reasoning and easier integration with AI libraries, the reasoning component has been refactored into a standalone Python module located in `src/python/internal_reasoning_engine.py`. The PowerShell orchestration engine invokes this module for complex analysis, ensuring language-agnostic operation and modern extensibility. You can also run the engine directly:
+
+```bash
+python -m src.python.internal_reasoning_engine --issue '{"Type":"ToolError","Error":"timeout"}' --context '{}'
+```
 
 ```powershell
 $issue = @{ Type = 'ValidationFailure'; ValidationResult = $result }
@@ -227,7 +231,9 @@ docker run -p 8080:8080 pierce-mcp
 
 The container launches a FastAPI gateway that relays requests to the PowerShell
 orchestration engine. Specify an alternate script path with the `MCP_SCRIPT`
-environment variable if required.
+environment variable if required. The gateway imports `src/Mcp.Core.psm1` before
+starting the server to avoid type-loading errors. Override the module location
+with `MCP_CORE_MODULE` if your layout differs.
 
 ### Enterprise Deployment
 For production environments, refer to the deployment guide in `/docs/deployment/` for:

--- a/scripts/test-core-modules.ps1
+++ b/scripts/test-core-modules.ps1
@@ -45,4 +45,8 @@ foreach ($module in $coreModules) {
     }
 }
 
+Write-Host "`n🎯 Testing Mcp.Core.psm1..." -ForegroundColor Cyan
+Import-Module (Join-Path $sourceRoot 'Mcp.Core.psm1') -Force
+Write-Host "✅ Mcp.Core.psm1 imported successfully" -ForegroundColor Green
+
 Write-Host "✅ Module testing complete" -ForegroundColor Green

--- a/src/Core/PRSuggestionEngine.ps1
+++ b/src/Core/PRSuggestionEngine.ps1
@@ -1,5 +1,5 @@
 #Requires -Version 7.0
-<%
+<#
 .SYNOPSIS
     Pull Request Suggestion Engine for MCP Server
 .DESCRIPTION
@@ -9,7 +9,7 @@
 .NOTES
     Author: Pierce County IT Solutions Architecture
     Compliance: GCC, SOC2, NIST
-%>
+#>
 
 using namespace System.IO
 
@@ -48,10 +48,17 @@ class PRSuggestionEngine {
             }
         }
 
-        $logBody = $testLog -join "`n"
-        $prBody = "### Change Description`n$changeDescription`n`n### Affected Files`n$files`n`n### Test Logs`n```
-$logBody
-```"
+        $logBodyJoined = $testLog -join "`n"
+        $prBody = @"
+### Change Description
+$changeDescription
+
+### Affected Files
+$files
+
+### Test Logs
+$logBodyJoined
+"@
 
         gh pr create --base $this.BaseBranch --head $branch --title $changeDescription --body $prBody | Out-Null
         $prUrl = gh pr view --json url -q '.url'

--- a/src/Mcp.Core.psm1
+++ b/src/Mcp.Core.psm1
@@ -1,0 +1,34 @@
+$baseDir = Split-Path -Parent $PSCommandPath
+$coreDir = Join-Path $baseDir 'Core'
+$files = @(
+    'Logger.ps1',
+    'OrchestrationTypes.ps1',
+    'SemanticIndex.ps1',
+    'VectorMemoryBank.ps1',
+    'ValidationEngine.ps1',
+    'SecurityManager.ps1',
+    'ToolRegistry.ps1',
+    'ContextManager.ps1',
+    'ConfidenceEngine.ps1',
+    'CodeExecutionEngine.ps1',
+    'HealthMonitor.ps1',
+    'StateMachine.ps1',
+    'InternalReasoningEngine.ps1',
+    'RuleBasedParser.ps1',
+    'EntityExtractor.ps1',
+    'AIManager.ps1',
+    'WebSearchEngine.ps1',
+    'PRSuggestionEngine.ps1',
+    'MCPServerClass.ps1',
+    'OrchestrationEngine.ps1',
+    'AsyncRequestProcessor.ps1'
+)
+foreach ($file in $files) {
+    $path = Join-Path $coreDir $file
+    if (Test-Path $path) {
+        . $path
+    } else {
+        Write-Warning "Module file missing: $path"
+    }
+}
+Export-ModuleMember *


### PR DESCRIPTION
## Summary
- package all core PowerShell classes in new `Mcp.Core.psm1`
- import module in FastAPI bridge via new `MCP_CORE_MODULE` env var
- enhance Python InternalReasoningEngine with validation, root-cause analysis and CLI
- fix `PRSuggestionEngine` comments and string building
- update test script and docs

## Testing
- `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/test-core-modules.ps1`

------
https://chatgpt.com/codex/tasks/task_e_685eeb19bc10832d8ff952229376f5f7