### PR TITLE
Fix PSVersion variable reference in MCPServerClass

### DIFF
--- a/src/Core/MCPServerClass.ps1
+++ b/src/Core/MCPServerClass.ps1
@@ -31,10 +31,11 @@ class MCPServer {
     
     hidden [void] Initialize() {
         try {
+            $psVersion = (Get-Variable -Name PSVersionTable -ValueOnly).PSVersion.ToString()
             $this.Logger.Info("Initializing Pierce County M365 MCP Server", @{
                 Version = $this.ServerVersion
                 StartTime = $this.StartTime
-                PowerShellVersion = $PSVersionTable.PSVersion.ToString()
+                PowerShellVersion = $psVersion
                 MachineName = $env:COMPUTERNAME
                 UserContext = $env:USERNAME
             })
@@ -622,7 +623,7 @@ class MCPServer {
         
         try {
             # Test PowerShell version
-            $psVersion = $PSVersionTable.PSVersion
+            $psVersion = (Get-Variable -Name PSVersionTable -ValueOnly).PSVersion
             if ($psVersion.Major -lt 7) {
                 $this.Logger.Warning("PowerShell version below 7.0", @{
                     CurrentVersion = $psVersion.ToString()


### PR DESCRIPTION
## Summary
- avoid direct reference to `$PSVersionTable` inside class methods
- use `Get-Variable` to fetch PowerShell version

## Testing
- `pwsh -File scripts/test-syntax.ps1`
- `pwsh -NoProfile -File scripts/test-core-modules.ps1`

------
https://chatgpt.com/codex/tasks/task_e_685ef1860c8c832da3b2558c10d757ab