### PR TITLE
Integrate Python reasoning engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,11 @@ $issue = @{ Type = 'ValidationFailure'; ValidationResult = $result }
 $resolution = $server.OrchestrationEngine.ReasoningEngine.Resolve($issue, $session)
 ```
 
+By default the PowerShell engine launches `python` from the system path. Set the
+`MCP_PYTHON` environment variable to override the executable if a specific
+runtime is required. The reasoning result is merged back into the workflow when
+the Python engine reports `resolved = true`.
+
 ### Confidence Interval Engine
 The Confidence Interval Engine continuously measures statistical confidence for entity extraction, validation, tool execution, and overall workflows. It calculates Wilson score intervals using historical outcomes and logs metrics for audit. When any lower bound falls below 95%, the engine invokes the Internal Reasoning Engine to re-analyze context and apply corrective strategies.
 


### PR DESCRIPTION
## Summary
- add Python engine fallback to InternalReasoningEngine
- allow custom Python path via `MCP_PYTHON`
- document the configuration in README

## Testing
- `pwsh -NoProfile -Command ./scripts/test-core-modules.ps1`
- `pwsh -NoProfile -Command ./scripts/test-syntax.ps1`
- `pwsh -NoProfile -Command ./scripts/test-memory-integration.ps1` *(fails: Unable to find type [SemanticIndex])* 
- `pwsh -NoProfile -Command ./scripts/test-mcp-modules.ps1` *(fails: Cannot bind argument to parameter 'Path' because it is null)*
- `pwsh -NoProfile -Command ./scripts/test-code-execution.ps1` *(fails: Cannot call a method on a null-valued expression)*

------
https://chatgpt.com/codex/tasks/task_e_685ef61ab788832daaaf7cdd62e7de89