### PR TITLE
Fix paths for logger/context and parser warnings

### DIFF
--- a/src/Core/ContextManager.ps1
+++ b/src/Core/ContextManager.ps1
@@ -22,7 +22,8 @@ class ContextManager {
     ContextManager([Logger]$logger) {
         $this.Logger = $logger
         $this.ContextStores = [ConcurrentDictionary[string, ContextStore]]::new()
-        $this.PersistencePath = Join-Path $env:TEMP "PierceCountyMCP\Context"
+        $temp = if ($env:TEMP) { $env:TEMP } else { '/tmp' }
+        $this.PersistencePath = Join-Path $temp "PierceCountyMCP/Context"
         $this.VectorMemoryBank = [VectorMemoryBank]::new($logger, (Join-Path $this.PersistencePath "VectorMemory"))
         $this.RelationshipGraph = [RelationshipGraph]::new($logger)
         

--- a/src/Core/Logger.ps1
+++ b/src/Core/Logger.ps1
@@ -140,7 +140,8 @@ class Logger {
         $this.AddTarget($consoleTarget)
         
         # File target for all logs
-        $logDir = Join-Path $env:TEMP "PierceCountyMCP\Logs"
+        $temp = if ($env:TEMP) { $env:TEMP } else { '/tmp' }
+        $logDir = Join-Path $temp "PierceCountyMCP/Logs"
         if (-not (Test-Path $logDir)) {
             New-Item -Path $logDir -ItemType Directory -Force | Out-Null
         }

--- a/src/Core/MCPServerClass.ps1
+++ b/src/Core/MCPServerClass.ps1
@@ -154,6 +154,7 @@ class MCPServer {
     
     hidden [hashtable] HandleRequest([hashtable]$request) {
         $this.PerformanceMonitor.StartOperation("MessageProcessing")
+        $success = $true
         
         try {
             # Log incoming request (sanitized)
@@ -192,6 +193,8 @@ class MCPServer {
                     }
                 }
             }
+
+            return $null
         }
         catch {
             $this.Logger.Error("Request handling failed", @{
@@ -394,6 +397,7 @@ class MCPServer {
     hidden [hashtable] HandlePromptsGet([hashtable]$request) {
         $promptName = $request.params.name
         $arguments = $request.params.arguments
+        $prompt = ""
         
         switch ($promptName) {
             "enterprise_analysis" {
@@ -467,6 +471,7 @@ class MCPServer {
     
     hidden [hashtable] HandleResourcesRead([hashtable]$request) {
         $uri = $request.params.uri
+        $content = ""
         
         switch -Regex ($uri) {
             "pierce://docs/governance" {

--- a/tests/test_reasoning.py
+++ b/tests/test_reasoning.py
@@ -1,4 +1,8 @@
+import os
+import sys
 import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from src.python.internal_reasoning_engine import InternalReasoningEngine
 
 class ReasoningTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- avoid null temp path in Logger default targets
- store context under /tmp if $TEMP not defined
- initialize success flag in request handler
- ensure prompt and content variables defined
- fix path setup in tests

## Testing
- `pwsh -File scripts/test-mcp-modules.ps1`
- `pwsh -File scripts/test-core-modules.ps1`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685efab92620832dbfc2315b99834fb4