### PR TITLE
Improve identifier parsing in reasoning engine

### DIFF
--- a/tests/test_reasoning.py
+++ b/tests/test_reasoning.py
@@ -27,6 +27,16 @@ class ReasoningTests(unittest.TestCase):
         self.assertFalse(res.resolved)
         self.assertIn("Escalation", res.resolution)
 
+    def test_extract_identifier_email(self):
+        text = "Error: user alice.jones@example.com not found"
+        ident = self.engine._extract_identifier(text)
+        self.assertEqual(ident, "alice.jones@example.com")
+
+    def test_extract_identifier_token(self):
+        text = "Validation failed for mailbox shared_mailbox_01"
+        ident = self.engine._extract_identifier(text)
+        self.assertEqual(ident, "shared_mailbox_01")
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- refine logic for parsing identifiers from validation text
- add environment context helper and next-step suggestions
- expand reasoning unit tests for identifier extraction

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685efc333b18832d9b852cdf73be2b44