### PR TITLE
Fix server config load

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,8 @@ $search = $server.OrchestrationEngine.WebSearchEngine.Search('m365 mailbox deleg
 8. Validate the installation by running `./scripts/test-core-modules.ps1`. This
    script loads core modules in dependency order starting with `Logger.ps1` and
    the new `OrchestrationTypes.ps1` definitions.
+9. Start the server with `pwsh ./src/MCPServer.ps1`. The default
+   configuration in `mcp.config.json` is loaded automatically.
 
 ### Configurable AI Model Providers
 AI providers are defined in `mcp.config.json`. Each provider entry includes an endpoint, model name, authentication, and timeout. Example:

--- a/src/MCPServer.ps1
+++ b/src/MCPServer.ps1
@@ -77,29 +77,6 @@ $script:logger = $null
 $script:performanceMonitor = $null
 $script:isShuttingDown = $false
 
-# Initialize the server
-try {
-    $config = @{
-        LogLevel = $LogLevel
-        ConfigPath = $ConfigPath
-        EnableDiagnostics = $EnableDiagnostics
-        ServerVersion = "2.1.0-rc"
-    }
-    
-    $script:logger = [Logger]::new([LogLevel]::Parse([LogLevel], $LogLevel, $true))
-    $script:logger.Info("Starting Pierce County M365 MCP Server v2.1.0-rc")
-
-    $aiManager = [AIManager]::new($script:logger, $config)
-    $script:orchestrationEngine = [OrchestrationEngine]::new($script:logger, $aiManager)
-    $script:performanceMonitor = [PerformanceMonitor]::new($script:logger)
-    
-    $server = [MCPServer]::new($script:logger, $config)
-    $server.Start()
-}
-catch {
-    Write-Error "Failed to start MCP Server: $_"
-    exit 1
-}
 function Initialize-Configuration {
     param(
         [string]$LogLevel,


### PR DESCRIPTION
## Summary
- remove premature server startup block
- clarify how to start server and automatic config loading in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685f04847a6c832dad1dc78464d7d07c