### PR TITLE
Fix config validation and module order

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ AI providers are defined in `mcp.config.json`. Each provider entry includes an e
 ```
 
 Swap providers or add new ones by editing this file and restarting the server. No code changes are required.
+The server validates that at least one provider is defined and that `DefaultAIProvider` matches an entry in the `AIProviders` array.
 
 ### Autostart Service
 Use `scripts/install-autostart.ps1` to register the watchdog service that keeps

--- a/src/MCPServer.ps1
+++ b/src/MCPServer.ps1
@@ -111,8 +111,26 @@ function Initialize-Configuration {
     if (-not $config.ContainsKey('AIProviders')) {
         $config.AIProviders = @()
     }
-    
+
+    Validate-Configuration -Config $config
+
     return $config
+}
+
+function Validate-Configuration {
+    param([hashtable]$Config)
+
+    if (-not $Config.AIProviders -or $Config.AIProviders.Count -eq 0) {
+        throw "Configuration must include at least one AI provider"
+    }
+
+    $default = $Config.DefaultAIProvider
+    if ($default) {
+        $names = $Config.AIProviders | ForEach-Object { $_.Name }
+        if ($names -notcontains $default) {
+            throw "DefaultAIProvider '$default' not found in AIProviders list"
+        }
+    }
 }
 
 function Start-MCPServer {

--- a/src/Mcp.Core.psm1
+++ b/src/Mcp.Core.psm1
@@ -19,9 +19,9 @@ $files = @(
     'AIManager.ps1',
     'WebSearchEngine.ps1',
     'PRSuggestionEngine.ps1',
-    'MCPServerClass.ps1',
     'OrchestrationEngine.ps1',
-    'AsyncRequestProcessor.ps1'
+    'AsyncRequestProcessor.ps1',
+    'MCPServerClass.ps1'
 )
 foreach ($file in $files) {
     $path = Join-Path $coreDir $file


### PR DESCRIPTION
## Summary
- validate configuration to ensure default AI provider exists in mcp.config.json
- load orchestration engine modules before MCP server class
- document provider validation in README

## Testing
- `pwsh -NoProfile -Command ./scripts/test-core-modules.ps1`
- `pwsh -NoProfile -File scripts/test-syntax.ps1`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f0732e748832d950ec8b3fc54a8ce