### PR TITLE
Add server mode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,17 @@ AI providers are defined in `mcp.config.json`. Each provider entry includes an e
 Swap providers or add new ones by editing this file and restarting the server. No code changes are required.
 The server validates that at least one provider is defined and that `DefaultAIProvider` matches an entry in the `AIProviders` array.
 
+### Server Modes
+The server can operate in three modes depending on the invocation context.
+
+| Mode | Description |
+|------|-------------|
+| **Admin** | Direct CLI or AI driven administration. All features and AI based reasoning are enabled. |
+| **JiraAutomation** | Triggered automatically by Jira issues. AI assistance is permitted for entity parsing and workflow orchestration. |
+| **JiraAutomationNoAI** | Used when Jira automation must run without any AI services. Entity parsing and orchestration rely only on deterministic rules. |
+
+Specify the desired mode with the `-Mode` parameter or the `MCP_MODE` environment variable when starting `MCPServer.ps1`.
+
 ### Autostart Service
 Use `scripts/install-autostart.ps1` to register the watchdog service that keeps
 the MCP server running. The script detects Windows or Linux and installs either

--- a/src/Core/MCPServerClass.ps1
+++ b/src/Core/MCPServerClass.ps1
@@ -18,10 +18,12 @@ class MCPServer {
     hidden [string] $ServerVersion
     hidden [DateTime] $StartTime
     hidden [bool] $IsInitialized
+    hidden [ServerMode] $Mode
     
-    MCPServer([Logger]$logger, [hashtable]$config) {
+    MCPServer([Logger]$logger, [hashtable]$config, [ServerMode]$mode) {
         $this.Logger = $logger
         $this.Configuration = $config
+        $this.Mode = $mode
         $this.ServerVersion = "2.1.0-rc"
         $this.StartTime = Get-Date
         $this.IsInitialized = $false
@@ -44,9 +46,11 @@ class MCPServer {
             $this.PerformanceMonitor = [PerformanceMonitor]::new($this.Logger)
             $this.HealthMonitor = [HealthMonitor]::new($this.Logger)
             
-            # Initialize AI manager and orchestration engine
-            $this.AIManager = [AIManager]::new($this.Logger, $this.Configuration)
-            $this.OrchestrationEngine = [OrchestrationEngine]::new($this.Logger, $this.AIManager)
+            # Initialize AI manager based on server mode
+            if ($this.Mode -ne [ServerMode]::JiraAutomationNoAI) {
+                $this.AIManager = [AIManager]::new($this.Logger, $this.Configuration)
+            }
+            $this.OrchestrationEngine = [OrchestrationEngine]::new($this.Logger, $this.AIManager, $this.Mode)
             $this.AsyncProcessor = [AsyncRequestProcessor]::new($this.OrchestrationEngine, $this.Logger, 4)
             
             # Register enterprise tools

--- a/src/Core/OrchestrationEngine.ps1
+++ b/src/Core/OrchestrationEngine.ps1
@@ -35,8 +35,9 @@ class OrchestrationEngine {
     hidden [CodeExecutionEngine] $CodeExecutionEngine
     hidden [WebSearchEngine] $WebSearchEngine
     hidden [System.Collections.Generic.List[hashtable]] $Checkpoints
-    
-    OrchestrationEngine([Logger]$logger, [AIManager]$aiManager) {
+    hidden [ServerMode] $Mode
+
+    OrchestrationEngine([Logger]$logger, [AIManager]$aiManager, [ServerMode]$mode) {
         $this.Memory = [ConcurrentDictionary[string, object]]::new()
         $this.Tools = [ConcurrentDictionary[string, object]]::new()
         $this.ActiveSessions = [ConcurrentDictionary[string, object]]::new()
@@ -48,6 +49,7 @@ class OrchestrationEngine {
         $this.ToolRegistry = [ToolRegistry]::new($logger)
         $this.ContextManager = [ContextManager]::new($logger)
         $this.AIManager = $aiManager
+        $this.Mode = $mode
         $this.CodeExecutionEngine = [CodeExecutionEngine]::new($logger)
         $this.WebSearchEngine = [WebSearchEngine]::new($logger)
         $this.ReasoningEngine = [InternalReasoningEngine]::new($logger, $this.ContextManager, $this.CodeExecutionEngine)
@@ -58,7 +60,7 @@ class OrchestrationEngine {
     }
     
     hidden [void] InitializeEngine() {
-        $this.Logger.Info("Initializing Enterprise Orchestration Engine")
+        $this.Logger.Info("Initializing Enterprise Orchestration Engine", @{ Mode = $this.Mode })
         
         try {
             # Load organizational context and standards

--- a/src/Core/OrchestrationTypes.ps1
+++ b/src/Core/OrchestrationTypes.ps1
@@ -24,6 +24,12 @@ enum ToolExecutionStatus {
     Retrying
 }
 
+enum ServerMode {
+    Admin
+    JiraAutomation
+    JiraAutomationNoAI
+}
+
 class OrchestrationRequest {
     [string] $Type
     [string] $Input

--- a/src/MCPServer.ps1
+++ b/src/MCPServer.ps1
@@ -22,7 +22,15 @@ param(
     [string]$Mode = 'Admin'
 )
 
-if ($env:MCP_MODE) { $Mode = $env:MCP_MODE }
+if ($env:MCP_MODE) {
+    $validModes = @('Admin', 'JiraAutomation', 'JiraAutomationNoAI')
+    $trimmedMode = $env:MCP_MODE.Trim()
+    if ($validModes -contains $trimmedMode) {
+        $Mode = $trimmedMode
+    } else {
+        Write-Warning "Invalid MCP_MODE value: '$env:MCP_MODE'. Falling back to default Mode: '$Mode'."
+    }
+}
 
 # Set strict mode and error handling
 Set-StrictMode -Version Latest

--- a/src/MCPServer.ps1
+++ b/src/MCPServer.ps1
@@ -17,8 +17,12 @@
 param(
     [string]$LogLevel = "INFO",
     [string]$ConfigPath = $null,
-    [switch]$EnableDiagnostics = $false
+    [switch]$EnableDiagnostics = $false,
+    [ValidateSet('Admin','JiraAutomation','JiraAutomationNoAI')]
+    [string]$Mode = 'Admin'
 )
+
+if ($env:MCP_MODE) { $Mode = $env:MCP_MODE }
 
 # Set strict mode and error handling
 Set-StrictMode -Version Latest
@@ -81,7 +85,8 @@ function Initialize-Configuration {
     param(
         [string]$LogLevel,
         [string]$ConfigPath,
-        [bool]$EnableDiagnostics
+        [bool]$EnableDiagnostics,
+        [string]$Mode
     )
     
     $config = @{
@@ -89,6 +94,7 @@ function Initialize-Configuration {
         ToolsDirectory = Join-Path $moduleRoot "tools"
         EnableDiagnostics = $EnableDiagnostics
         ServerVersion = "2.1.0-rc"
+        Mode = $Mode
     }
     
     # Load configuration file if specified, otherwise try repo config
@@ -131,19 +137,26 @@ function Validate-Configuration {
             throw "DefaultAIProvider '$default' not found in AIProviders list"
         }
     }
+
+    if (-not $Config.ContainsKey('Mode')) { throw "Server mode not specified" }
 }
 
 function Start-MCPServer {
     try {
         # Initialize configuration
-        $config = Initialize-Configuration -LogLevel $LogLevel -ConfigPath $ConfigPath -EnableDiagnostics $EnableDiagnostics
+        $config = Initialize-Configuration -LogLevel $LogLevel -ConfigPath $ConfigPath -EnableDiagnostics $EnableDiagnostics -Mode $Mode
         
         # Initialize logger
         $logLevelEnum = [LogLevel]::Parse([LogLevel], $config.LogLevel, $true)
         $script:logger = [Logger]::new($logLevelEnum)
         
         # Create and start server
-        $server = [MCPServer]::new($script:logger, $config)
+        try {
+            $serverMode = [System.Enum]::Parse([ServerMode], $config.Mode, $true)
+        } catch {
+            throw "Invalid server mode: $($config.Mode)"
+        }
+        $server = [MCPServer]::new($script:logger, $config, $serverMode)
         $script:orchestrationEngine = $server.OrchestrationEngine
         $script:performanceMonitor = $server.PerformanceMonitor
         


### PR DESCRIPTION
## Summary
- add `ServerMode` enum for Admin and Jira automation contexts
- initialize `MCPServer` and `OrchestrationEngine` with chosen mode
- allow `MCPServer.ps1` to accept a `-Mode` parameter or `MCP_MODE` env var
- disable AI manager when running in JiraAutomationNoAI mode
- document modes in README

## Testing
- `python -m pytest -q`
- `pwsh ./scripts/test-core-modules.ps1`
- `pwsh ./scripts/test-syntax.ps1`
- `pwsh ./scripts/validate-architecture.ps1` *(produces warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6862d2ef15cc832d977911481bb0fd45